### PR TITLE
Add functionality to add(channel) commands

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -241,6 +241,7 @@ async def setApproverChannel(ctx, channelName):
 
 
     try: 
+        channelName = channelName.lstrip('#')
         log.debug("Approval Channel: " + channelName)
         approval_channel = discord.utils.get(ctx.guild.text_channels, name=channelName) 
         if (approval_channel is None):
@@ -314,6 +315,7 @@ async def setPublicChannel(ctx, channelName):
 
     # Get the channel ID
     try: 
+        channelName = channelName.lstrip('#')
         approval_pubchannel = discord.utils.get(ctx.guild.text_channels, name=channelName)
         log.debug(approval_pubchannel)
         if (approval_pubchannel is None):


### PR DESCRIPTION
Allow pound symbols at beginnings of channel names when invoking setApproverChannel or setPublicChannel

I think this is desirable because Discord automatically prompts you to autocomplete channel names when you start typing them, but only while including the pound symbol at the front. Channel names themselves cannot begin with pound symbols so there's no chance of this causing future bugs. 